### PR TITLE
Add Helm Support

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/ubuntu:14.04
+FROM ppc64le/ubuntu:16.04
 
 RUN apt-get update -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y apache2 python-pip \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,25 @@
+node {
+    dir("/root/"){
+    checkout scm
+
+    env.DOCKER_API_VERSION="1.23"
+    appName = "default/flask-app"
+    registryHost = "mycluster.icp:8500/"
+    imageName = "${registryHost}${appName}:${env.BUILD_ID}"
+    env.BUILDIMG=imageName
+    docker.withRegistry('https://mycluster.icp:8500/', 'docker'){
+    stage "Build"
+
+        def pcImg = docker.build("mycluster.icp:8500/default/flask-app:${env.BUILD_ID}", "-f Dockerfile.ppc64le .")
+        sh "cp /root/.dockercfg ${HOME}/.dockercfg"
+        pcImg.push()
+
+    input 'Do you want to proceed with Deployment?'
+    stage "Deploy"
+
+        sh "kubectl set image deployment/demoapp-demochart demochart=${imageName}"
+        sh "kubectl rollout status deployment/demoapp-demochart"
+}
+}
+}
+

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-This code is a fork of the following [code](https://github.com/jay3dec/PythonFlaskMySQLApp---Part-1) and is used to demonstrate dockerized deployment.
-Explanation of the code is provided [here](http://code.tutsplus.com/tutorials/creating-a-web-app-from-scratch-using-python-flask-and-mysql--cms-22972)
 
-#Build
- docker build -t flaskapp .
-  
- For building it on PowerPC LE platform do this
- docker build -t ppc64le/flaskapp -f Dockerfile.ppc64le .
+### Overview
+ This code is a fork of the following [code](https://github.com/jay3dec/PythonFlaskMySQLApp---Part-1) and is used to demonstrate dockerized deployment.
+ Explanation of the code is provided [here](http://code.tutsplus.com/tutorials/creating-a-web-app-from-scratch-using-python-flask-and-mysql--cms-22972)
+
+### Build
+
+To build this for ppc64le arch, do the following:
+
+    `docker build -t ppc64le/flaskapp -f Dockerfile.ppc64le .`
      
-#Run
- docker run -itd -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DB=test --link mysql:db  -p 8080:80 flaskapp
+### Deploy in a Kubernetes cluster
 
-#MySQL DB Setup
-Refer to db_setup file
+ - Install the `helm` CLI and ensure it's working against your kubernetes cluster. 
+ - Ensure that you have a mariadb service running.
+ - Simply clone the repository and run the following from the `sampleflaskapp` directory:
 
+    `helm install --name demoapp helmchart`

--- a/helmchart/.helmignore
+++ b/helmchart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helmchart/Chart.yaml
+++ b/helmchart/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+description: A Helm chart for the flaskapp
+name: demochart
+version: 0.1.0
+maintainers:
+- name: sudipta
+  email: sbiswas7@in.ibm.com
+- name: pradipta
+  email: bpradipt@in.ibm.com

--- a/helmchart/templates/NOTES.txt
+++ b/helmchart/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+{{- end }}

--- a/helmchart/templates/_helpers.tpl
+++ b/helmchart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helmchart/templates/deployment.yaml
+++ b/helmchart/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          env:
+          - name: "MYSQL_ROOT_PASSWORD"
+            value: {{.Values.MYSQL_ROOT_PASSWORD}}
+          - name: "MYSQL_USER"
+            value: {{.Values.MYSQL_USER}}
+          - name: "MYSQL_PASSWORD"
+            value: {{.Values.MYSQL_PASSWORD}}
+          - name: "MYSQL_DB"
+            value: {{.Values.MYSQL_DB}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/helmchart/templates/ingress.yaml
+++ b/helmchart/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/helmchart/templates/service.yaml
+++ b/helmchart/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -1,0 +1,42 @@
+# Default values for demochart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: mycluster.icp:8500/default/demoapp
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  name: demoapp
+  type: NodePort
+  externalPort: 8080
+  internalPort: 80
+ingress:
+  enabled: true
+  # Used to create an Ingress record.
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+MYSQL_ROOT_PASSWORD: password
+MYSQL_USER: user
+MYSQL_PASSWORD: pass
+MYSQL_DB: test


### PR DESCRIPTION
 This commit adds the Helm chart for the flaskapp.
 Once this repo is cloned, one should be simply able to run
 helm install to deploy this application on a kubernetes cluster.